### PR TITLE
Update metadata.json to reflect the 1.4 release as per the last merge…

### DIFF
--- a/xExtension-AutoRefresh/metadata.json
+++ b/xExtension-AutoRefresh/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Auto Refresh",
 	"author": "Essa AlAwadi",
 	"description": "Automatically refreshes the RSS feed when there is no activity",
-	"version": 1.3,
+	"version": 1.4,
 	"entrypoint": "AutoRefresh",
 	"type": "user"
 }


### PR DESCRIPTION
… from math

Update metadata.json to reflect the 1.4 release as per the last merge from math back in 2021, as the current version is still showing as 1.3 instead of 1.4.